### PR TITLE
m1cpu: handle `kIOMainPortDefault` for macOS < 12

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -3,9 +3,14 @@
 package m1cpu
 
 // #cgo LDFLAGS: -framework CoreFoundation -framework IOKit
+// #include <AvailabilityMacros.h>
 // #include <CoreFoundation/CoreFoundation.h>
 // #include <IOKit/IOKitLib.h>
 // #include <sys/sysctl.h>
+//
+// #ifndef MAC_OS_VERSION_12_0
+// #define kIOMainPortDefault kIOMasterPortDefault
+// #endif
 //
 // #define HzToGHz(hz) ((hz) / 1000000000.0)
 //


### PR DESCRIPTION
`kIOMainPortDefault` was renamed from `kIOMasterPortDefault` in macOS Monterey. This patch makes sure m1cpu can be built on Big Sur, too.

This issue was discovered while packaging [Telegraf](https://github.com/influxdata/telegraf) (an indirect dependant of m1cpu) for Homebrew at https://github.com/Homebrew/homebrew-core/pull/127477.
