### PR TITLE
Handle kIOMainPortDefault when targeting macOS < 12 with a new SDK

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -8,7 +8,7 @@ package m1cpu
 // #include <IOKit/IOKitLib.h>
 // #include <sys/sysctl.h>
 //
-// #ifndef MAC_OS_VERSION_12_0
+// #if !defined(MAC_OS_VERSION_12_0) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_VERSION_12_0
 // #define kIOMainPortDefault kIOMasterPortDefault
 // #endif
 //


### PR DESCRIPTION
When building with  macOS SDK >= 12.0, and targeting macOS Big Sur (10.16/11.0), the `MAC_OS_VERSION_12_0` macro is defined, but we still can't use the `kIOMainPortDefault` definition, as it was only introduced on macOS 12.0. The previous patch only handles the case of compiling directly with macOS SDK versions < 12.0, but fails to address targeting earlier OS versions with new version of the SDK.
Currently, the module compiles with the following warning, and this patch fixes it:
```
/go/pkg/mod/github.com/shoenig/go-m1cpu@v0.1.5/cpu.go:70:33: warning: 'kIOMainPortDefault' is only available on macOS 12.0 or newer [-Wunguarded-availability-new]
/go/pkg/mod/github.com/shoenig/go-m1cpu@v0.1.5/cpu.go:70:33: note: 'kIOMainPortDefault' has been marked as being introduced in macOS 12.0 here, but the deployment target is macOS 10.16.0
/go/pkg/mod/github.com/shoenig/go-m1cpu@v0.1.5/cpu.go:70:33: note: enclose 'kIOMainPortDefault' in a __builtin_available check to silence this warning
```