### PR TITLE
ci: add macos-13-xlarge runs-on target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-11
           - macos-12
+          - macos-13-xlarge
           - ubuntu-22.04
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
GitHub has added runners backed by Apple Silicon
https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
