### PR TITLE
fix error: 'kIOMasterPortDefault' is unavailable: not available on iOS

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -67,7 +67,7 @@ package m1cpu
 //
 //   CFMutableDictionaryRef matching = IOServiceMatching("AppleARMIODevice");
 //   io_iterator_t  iter;
-//   IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iter);
+//   IOServiceGetMatchingServices(MACH_PORT_NULL, matching, &iter);
 //
 //   const size_t bufsize = 512;
 //   io_object_t obj;


### PR DESCRIPTION
test on m1 cpu ,macos and ios build