### PR TITLE
fix segfault with m5 cpu

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -30,6 +30,9 @@ package m1cpu
 // char global_brand[32];
 //
 // UInt64 getFrequency(CFTypeRef typeRef) {
+//  if (typeRef == NULL) {
+//    return 0;
+//  }
 //  CFDataRef cfData = typeRef;
 //
 //  CFIndex size = CFDataGetLength(cfData);
@@ -80,8 +83,9 @@ package m1cpu
 //     IORegistryEntryGetName(obj, name);
 //
 //     if (strncmp(name, "pmgr", BUFSIZE) == 0) {
-//       CFTypeRef pCoreRef = IORegistryEntryCreateCFProperty(obj, CFSTR("voltage-states5-sram"), kCFAllocatorDefault, 0);
-//       CFTypeRef eCoreRef = IORegistryEntryCreateCFProperty(obj, CFSTR("voltage-states1-sram"), kCFAllocatorDefault, 0);
+//       CFTypeRef pCoreRef = NULL, eCoreRef = NULL;
+//       pCoreRef = IORegistryEntryCreateCFProperty(obj, CFSTR("voltage-states5-sram"), kCFAllocatorDefault, 0);
+//       eCoreRef = IORegistryEntryCreateCFProperty(obj, CFSTR("voltage-states1-sram"), kCFAllocatorDefault, 0);
 //
 //       long long pCoreClock = getFrequency(pCoreRef);
 //       long long eCoreClock = getFrequency(eCoreRef);


### PR DESCRIPTION
Hello again @shoenig!

This is admittedly a bit of a guess, so feel free to pass up on this PR. I was looking at why this code is seg faulting and `gopsutil` apparently isn't (which is using basically the same logic, just now with purego). `gopsutil` does not check for ecores, and I also noticed that the M5 Pro and Max [do not have ecores](https://www.apple.com/newsroom/2026/03/apple-debuts-m5-pro-and-m5-max-to-supercharge-the-most-demanding-pro-workflows/). So here I'm just doing a little bit of NULL initialization and checking to exit before we would seg fault.

This _should_ fix #25 (but unfortunately I can't test this to confirm)