### PR TITLE
fix CFRelease NULL crash on M5 Pro/Max

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -92,8 +92,8 @@ package m1cpu
 //
 //       global_pCoreClock = pCoreClock;
 //       global_eCoreClock = eCoreClock;
-//  	 CFRelease(pCoreRef);
-//  	 CFRelease(eCoreRef);
+//  	 if (pCoreRef) CFRelease(pCoreRef);
+//  	 if (eCoreRef) CFRelease(eCoreRef);
 //		 break;
 //     }
 //   }


### PR DESCRIPTION
Hi @shoenig!

PR #27 fixed the `getFrequency()` segfault on M5 by adding a NULL check, but the `CFRelease` calls added in #26 still receive NULL when the IOKit `voltage-states` properties don't exist (M5 Pro/Max lack E-cores, so `voltage-states1-sram` returns NULL).

[`CFRelease(NULL)` is undefined behavior](https://developer.apple.com/documentation/corefoundation/1521153-cfrelease) and crashes the process, so v0.2.0 still segfaults on M5.

This adds NULL guards to both `CFRelease` calls:

```c
-  CFRelease(pCoreRef);
-  CFRelease(eCoreRef);
+  if (pCoreRef) CFRelease(pCoreRef);
+  if (eCoreRef) CFRelease(eCoreRef);
```

Should fully resolve #25.